### PR TITLE
Avoid Ada.Containers.Hash_Maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Ada library with implementation of WMM model for magnetic declination angle calc
 Use Alire to install and compile the library:
 
 ```
-alr with raiden --use https://github.com/MaxZakirov/geo_mag
+alr with geo_mag --use https://github.com/MaxZakirov/geo_mag
 ```
 
 ## Basic usage

--- a/src/geo_mag-magnetic_model.adb
+++ b/src/geo_mag-magnetic_model.adb
@@ -38,157 +38,123 @@ package body Geo_Mag.Magnetic_Model is
    end Timely_Adjust_Magnetic_Model;
 
    function Build_Magnetic_Model return Geo_Mag.Data.Magnetic_Model is
-      use WMM_Coefficients_Map;
       function Calculate_Index (N : Integer; M : Integer) return Integer
       renames Geo_Mag.Common.Calculate_Coef_Index;
 
-      WMM_Map : constant Map := Get_WMM_Ceofficients;
+      WMM_Map : constant Coefficient_Record_Array := Get_WMM_Ceofficients;
 
-      function Get_Max_Degree return Integer is
-      begin
-         for I in 1 .. Integer'Last loop
-            if not Contains (WMM_Map, (I + 1) * 100) then
-               return I;
-            end if;
-         end loop;
-
-         return 0;
-      end Get_Max_Degree;
-
-      Max_Degree      : constant Integer := Get_Max_Degree;
+      Max_Degree      : constant Integer := WMM_Map (WMM_Map'Last).Degree;
       Model_Base_Year : constant Float := 2025.0;
       Mag_Model       :
         Geo_Mag.Data.Magnetic_Model (Calculate_Index (Max_Degree, Max_Degree));
-      Map_Cursor      : Cursor := First (WMM_Map);
-      Model_Row       : Coefficients_Values;
 
-      Order, Degree, Index : Integer := 0;
+      Index : Integer := 0;
    begin
       Mag_Model.Max_Degree := Max_Degree;
       Mag_Model.Base_Year := Model_Base_Year;
 
-      while Has_Element (Map_Cursor) loop
-         Degree := Key (Map_Cursor) / 100;
-         Order := Key (Map_Cursor) rem 100;
+      for Row of WMM_Map loop
+         Index := Calculate_Index (Row.Degree, Row.Order);
 
-         Index := Calculate_Index (Degree, Order);
-         Model_Row := Element (Map_Cursor);
-         Mag_Model.Gauss_Coeff_G (Index) := Nanoteslas (Model_Row (1));
-         Mag_Model.Gauss_Coeff_H (Index) := Nanoteslas (Model_Row (2));
-         Mag_Model.Secular_Var_G (Index) :=
-           Nanoteslas_Per_Year (Model_Row (3));
-         Mag_Model.Secular_Var_H (Index) :=
-           Nanoteslas_Per_Year (Model_Row (4));
-
-         Next (Map_Cursor);
+         Mag_Model.Gauss_Coeff_G (Index) := Row.Gauss_Coeff_G;
+         Mag_Model.Gauss_Coeff_H (Index) := Row.Gauss_Coeff_H;
+         Mag_Model.Secular_Var_G (Index) := Row.Secular_Var_G;
+         Mag_Model.Secular_Var_H (Index) := Row.Secular_Var_H;
       end loop;
 
       return Mag_Model;
    end Build_Magnetic_Model;
 
-   function Hash_Int (Key : Integer) return Ada.Containers.Hash_Type is
-   begin
-      return Ada.Containers.Hash_Type (Key);
-   end Hash_Int;
-
-   function Get_WMM_Ceofficients return WMM_Coefficients_Map.Map is
-      use WMM_Coefficients_Map;
-
-      Map : WMM_Coefficients_Map.Map;
-   begin
-      Map.Reserve_Capacity (Ada.Containers.Count_Type (90));
-      Map.Insert (1_00, (-29351.8, 0.0, 12.0, 0.0));
-      Map.Insert (1_01, (-1410.8, 4545.4, 19.7, -21.5));
-      Map.Insert (2_00, (-2556.6, 0.0, -11.6, 0.0));
-      Map.Insert (2_01, (2951.1, -3133.6, -5.2, -27.7));
-      Map.Insert (2_02, (1649.3, -815.1, -8.0, -12.1));
-      Map.Insert (3_00, (1361.0, 0.0, -1.3, 0.0));
-      Map.Insert (3_01, (-2404.1, -56.6, -4.2, 4.0));
-      Map.Insert (3_02, (1243.8, 237.5, 0.4, -0.3));
-      Map.Insert (3_03, (453.6, -549.5, -15.6, -4.1));
-      Map.Insert (4_00, (895.0, 0.0, -1.6, 0.0));
-      Map.Insert (4_01, (799.5, 278.6, -2.4, -1.1));
-      Map.Insert (4_02, (55.7, -133.9, -6.0, 4.1));
-      Map.Insert (4_03, (-281.1, 212.0, 5.6, 1.6));
-      Map.Insert (4_04, (12.1, -375.6, -7.0, -4.4));
-      Map.Insert (5_00, (-233.2, 0.0, 0.6, 0.0));
-      Map.Insert (5_01, (368.9, 45.4, 1.4, -0.5));
-      Map.Insert (5_02, (187.2, 220.2, 0.0, 2.2));
-      Map.Insert (5_03, (-138.7, -122.9, 0.6, 0.4));
-      Map.Insert (5_04, (-142.0, 43.0, 2.2, 1.7));
-      Map.Insert (5_05, (20.9, 106.1, 0.9, 1.9));
-      Map.Insert (6_00, (64.4, 0.0, -0.2, 0.0));
-      Map.Insert (6_01, (63.8, -18.4, -0.4, 0.3));
-      Map.Insert (6_02, (76.9, 16.8, 0.9, -1.6));
-      Map.Insert (6_03, (-115.7, 48.8, 1.2, -0.4));
-      Map.Insert (6_04, (-40.9, -59.8, -0.9, 0.9));
-      Map.Insert (6_05, (14.9, 10.9, 0.3, 0.7));
-      Map.Insert (6_06, (-60.7, 72.7, 0.9, 0.9));
-      Map.Insert (7_00, (79.5, 0.0, -0.0, 0.0));
-      Map.Insert (7_01, (-77.0, -48.9, -0.1, 0.6));
-      Map.Insert (7_02, (-8.8, -14.4, -0.1, 0.5));
-      Map.Insert (7_03, (59.3, -1.0, 0.5, -0.8));
-      Map.Insert (7_04, (15.8, 23.4, -0.1, 0.0));
-      Map.Insert (7_05, (2.5, -7.4, -0.8, -1.0));
-      Map.Insert (7_06, (-11.1, -25.1, -0.8, 0.6));
-      Map.Insert (7_07, (14.2, -2.3, 0.8, -0.2));
-      Map.Insert (8_00, (23.2, 0.0, -0.1, 0.0));
-      Map.Insert (8_01, (10.8, 7.1, 0.2, -0.2));
-      Map.Insert (8_02, (-17.5, -12.6, 0.0, 0.5));
-      Map.Insert (8_03, (2.0, 11.4, 0.5, -0.4));
-      Map.Insert (8_04, (-21.7, -9.7, -0.1, 0.4));
-      Map.Insert (8_05, (16.9, 12.7, 0.3, -0.5));
-      Map.Insert (8_06, (15.0, 0.7, 0.2, -0.6));
-      Map.Insert (8_07, (-16.8, -5.2, -0.0, 0.3));
-      Map.Insert (8_08, (0.9, 3.9, 0.2, 0.2));
-      Map.Insert (9_00, (4.6, 0.0, -0.0, 0.0));
-      Map.Insert (9_01, (7.8, -24.8, -0.1, -0.3));
-      Map.Insert (9_02, (3.0, 12.2, 0.1, 0.3));
-      Map.Insert (9_03, (-0.2, 8.3, 0.3, -0.3));
-      Map.Insert (9_04, (-2.5, -3.3, -0.3, 0.3));
-      Map.Insert (9_05, (-13.1, -5.2, 0.0, 0.2));
-      Map.Insert (9_06, (2.4, 7.2, 0.3, -0.1));
-      Map.Insert (9_07, (8.6, -0.6, -0.1, -0.2));
-      Map.Insert (9_08, (-8.7, 0.8, 0.1, 0.4));
-      Map.Insert (9_09, (-12.9, 10.0, -0.1, 0.1));
-      Map.Insert (10_00, (-1.3, 0.0, 0.1, 0.0));
-      Map.Insert (10_01, (-6.4, 3.3, 0.0, 0.0));
-      Map.Insert (10_02, (0.2, 0.0, 0.1, -0.0));
-      Map.Insert (10_03, (2.0, 2.4, 0.1, -0.2));
-      Map.Insert (10_04, (-1.0, 5.3, -0.0, 0.1));
-      Map.Insert (10_05, (-0.6, -9.1, -0.3, -0.1));
-      Map.Insert (10_06, (-0.9, 0.4, 0.0, 0.1));
-      Map.Insert (10_07, (1.5, -4.2, -0.1, 0.0));
-      Map.Insert (10_08, (0.9, -3.8, -0.1, -0.1));
-      Map.Insert (10_09, (-2.7, 0.9, -0.0, 0.2));
-      Map.Insert (10_10, (-3.9, -9.1, -0.0, -0.0));
-      Map.Insert (11_00, (2.9, 0.0, 0.0, 0.0));
-      Map.Insert (11_01, (-1.5, 0.0, -0.0, -0.0));
-      Map.Insert (11_02, (-2.5, 2.9, 0.0, 0.1));
-      Map.Insert (11_03, (2.4, -0.6, 0.0, -0.0));
-      Map.Insert (11_04, (-0.6, 0.2, 0.0, 0.1));
-      Map.Insert (11_05, (-0.1, 0.5, -0.1, -0.0));
-      Map.Insert (11_06, (-0.6, -0.3, 0.0, -0.0));
-      Map.Insert (11_07, (-0.1, -1.2, -0.0, 0.1));
-      Map.Insert (11_08, (1.1, -1.7, -0.1, -0.0));
-      Map.Insert (11_09, (-1.0, -2.9, -0.1, 0.0));
-      Map.Insert (11_10, (-0.2, -1.8, -0.1, 0.0));
-      Map.Insert (11_11, (2.6, -2.3, -0.1, 0.0));
-      Map.Insert (12_00, (-2.0, 0.0, 0.0, 0.0));
-      Map.Insert (12_01, (-0.2, -1.3, 0.0, -0.0));
-      Map.Insert (12_02, (0.3, 0.7, -0.0, 0.0));
-      Map.Insert (12_03, (1.2, 1.0, -0.0, -0.1));
-      Map.Insert (12_04, (-1.3, -1.4, -0.0, 0.1));
-      Map.Insert (12_05, (0.6, -0.0, -0.0, -0.0));
-      Map.Insert (12_06, (0.6, 0.6, 0.1, -0.0));
-      Map.Insert (12_07, (0.5, -0.1, -0.0, -0.0));
-      Map.Insert (12_08, (-0.1, 0.8, 0.0, 0.0));
-      Map.Insert (12_09, (-0.4, 0.1, 0.0, -0.0));
-      Map.Insert (12_10, (-0.2, -1.0, -0.1, -0.0));
-      Map.Insert (12_11, (-1.3, 0.1, -0.0, 0.0));
-      Map.Insert (12_12, (-0.7, 0.2, -0.1, -0.1));
-
-      return Map;
-   end Get_WMM_Ceofficients;
+   function Get_WMM_Ceofficients return Coefficient_Record_Array is
+     ((1, 0, -29351.8, 0.0, 12.0, 0.0),
+      (1, 1, -1410.8, 4545.4, 19.7, -21.5),
+      (2, 0, -2556.6, 0.0, -11.6, 0.0),
+      (2, 1, 2951.1, -3133.6, -5.2, -27.7),
+      (2, 2, 1649.3, -815.1, -8.0, -12.1),
+      (3, 0, 1361.0, 0.0, -1.3, 0.0),
+      (3, 1, -2404.1, -56.6, -4.2, 4.0),
+      (3, 2, 1243.8, 237.5, 0.4, -0.3),
+      (3, 3, 453.6, -549.5, -15.6, -4.1),
+      (4, 0, 895.0, 0.0, -1.6, 0.0),
+      (4, 1, 799.5, 278.6, -2.4, -1.1),
+      (4, 2, 55.7, -133.9, -6.0, 4.1),
+      (4, 3, -281.1, 212.0, 5.6, 1.6),
+      (4, 4, 12.1, -375.6, -7.0, -4.4),
+      (5, 0, -233.2, 0.0, 0.6, 0.0),
+      (5, 1, 368.9, 45.4, 1.4, -0.5),
+      (5, 2, 187.2, 220.2, 0.0, 2.2),
+      (5, 3, -138.7, -122.9, 0.6, 0.4),
+      (5, 4, -142.0, 43.0, 2.2, 1.7),
+      (5, 5, 20.9, 106.1, 0.9, 1.9),
+      (6, 0, 64.4, 0.0, -0.2, 0.0),
+      (6, 1, 63.8, -18.4, -0.4, 0.3),
+      (6, 2, 76.9, 16.8, 0.9, -1.6),
+      (6, 3, -115.7, 48.8, 1.2, -0.4),
+      (6, 4, -40.9, -59.8, -0.9, 0.9),
+      (6, 5, 14.9, 10.9, 0.3, 0.7),
+      (6, 6, -60.7, 72.7, 0.9, 0.9),
+      (7, 0, 79.5, 0.0, -0.0, 0.0),
+      (7, 1, -77.0, -48.9, -0.1, 0.6),
+      (7, 2, -8.8, -14.4, -0.1, 0.5),
+      (7, 3, 59.3, -1.0, 0.5, -0.8),
+      (7, 4, 15.8, 23.4, -0.1, 0.0),
+      (7, 5, 2.5, -7.4, -0.8, -1.0),
+      (7, 6, -11.1, -25.1, -0.8, 0.6),
+      (7, 7, 14.2, -2.3, 0.8, -0.2),
+      (8, 0, 23.2, 0.0, -0.1, 0.0),
+      (8, 1, 10.8, 7.1, 0.2, -0.2),
+      (8, 2, -17.5, -12.6, 0.0, 0.5),
+      (8, 3, 2.0, 11.4, 0.5, -0.4),
+      (8, 4, -21.7, -9.7, -0.1, 0.4),
+      (8, 5, 16.9, 12.7, 0.3, -0.5),
+      (8, 6, 15.0, 0.7, 0.2, -0.6),
+      (8, 7, -16.8, -5.2, -0.0, 0.3),
+      (8, 8, 0.9, 3.9, 0.2, 0.2),
+      (9, 0, 4.6, 0.0, -0.0, 0.0),
+      (9, 1, 7.8, -24.8, -0.1, -0.3),
+      (9, 2, 3.0, 12.2, 0.1, 0.3),
+      (9, 3, -0.2, 8.3, 0.3, -0.3),
+      (9, 4, -2.5, -3.3, -0.3, 0.3),
+      (9, 5, -13.1, -5.2, 0.0, 0.2),
+      (9, 6, 2.4, 7.2, 0.3, -0.1),
+      (9, 7, 8.6, -0.6, -0.1, -0.2),
+      (9, 8, -8.7, 0.8, 0.1, 0.4),
+      (9, 9, -12.9, 10.0, -0.1, 0.1),
+      (10, 0, -1.3, 0.0, 0.1, 0.0),
+      (10, 1, -6.4, 3.3, 0.0, 0.0),
+      (10, 2, 0.2, 0.0, 0.1, -0.0),
+      (10, 3, 2.0, 2.4, 0.1, -0.2),
+      (10, 4, -1.0, 5.3, -0.0, 0.1),
+      (10, 5, -0.6, -9.1, -0.3, -0.1),
+      (10, 6, -0.9, 0.4, 0.0, 0.1),
+      (10, 7, 1.5, -4.2, -0.1, 0.0),
+      (10, 8, 0.9, -3.8, -0.1, -0.1),
+      (10, 9, -2.7, 0.9, -0.0, 0.2),
+      (10, 10, -3.9, -9.1, -0.0, -0.0),
+      (11, 0, 2.9, 0.0, 0.0, 0.0),
+      (11, 1, -1.5, 0.0, -0.0, -0.0),
+      (11, 2, -2.5, 2.9, 0.0, 0.1),
+      (11, 3, 2.4, -0.6, 0.0, -0.0),
+      (11, 4, -0.6, 0.2, 0.0, 0.1),
+      (11, 5, -0.1, 0.5, -0.1, -0.0),
+      (11, 6, -0.6, -0.3, 0.0, -0.0),
+      (11, 7, -0.1, -1.2, -0.0, 0.1),
+      (11, 8, 1.1, -1.7, -0.1, -0.0),
+      (11, 9, -1.0, -2.9, -0.1, 0.0),
+      (11, 10, -0.2, -1.8, -0.1, 0.0),
+      (11, 11, 2.6, -2.3, -0.1, 0.0),
+      (12, 0, -2.0, 0.0, 0.0, 0.0),
+      (12, 1, -0.2, -1.3, 0.0, -0.0),
+      (12, 2, 0.3, 0.7, -0.0, 0.0),
+      (12, 3, 1.2, 1.0, -0.0, -0.1),
+      (12, 4, -1.3, -1.4, -0.0, 0.1),
+      (12, 5, 0.6, -0.0, -0.0, -0.0),
+      (12, 6, 0.6, 0.6, 0.1, -0.0),
+      (12, 7, 0.5, -0.1, -0.0, -0.0),
+      (12, 8, -0.1, 0.8, 0.0, 0.0),
+      (12, 9, -0.4, 0.1, 0.0, -0.0),
+      (12, 10, -0.2, -1.0, -0.1, -0.0),
+      (12, 11, -1.3, 0.1, -0.0, 0.0),
+      (12, 12, -0.7, 0.2, -0.1, -0.1));
 
 end Geo_Mag.Magnetic_Model;

--- a/src/geo_mag-magnetic_model.ads
+++ b/src/geo_mag-magnetic_model.ads
@@ -4,8 +4,6 @@
 ----------------------------------------------------------------
 
 with Geo_Mag.Data;
-with Ada.Containers;
-with Ada.Containers.Hashed_Maps;
 
 private package Geo_Mag.Magnetic_Model is
    --  Time change the Model coefficients from the base year
@@ -22,16 +20,17 @@ private package Geo_Mag.Magnetic_Model is
 
 private
 
-   type Coefficients_Values is array (1 .. 4) of Float;
+   type Coefficient_Record is record
+      Degree        : Integer;
+      Order         : Integer;
+      Gauss_Coeff_G : Geo_Mag.Data.Nanoteslas;
+      Gauss_Coeff_H : Geo_Mag.Data.Nanoteslas;
+      Secular_Var_G : Geo_Mag.Data.Nanoteslas_Per_Year;
+      Secular_Var_H : Geo_Mag.Data.Nanoteslas_Per_Year;
+   end record;
 
-   function Hash_Int (Key : Integer) return Ada.Containers.Hash_Type;
+   type Coefficient_Record_Array is array (Positive range <>) of
+     Coefficient_Record;
 
-   package WMM_Coefficients_Map is new
-     Ada.Containers.Hashed_Maps
-       (Key_Type        => Integer,
-        Element_Type    => Coefficients_Values,
-        Hash            => Hash_Int,
-        Equivalent_Keys => "=");
-
-   function Get_WMM_Ceofficients return WMM_Coefficients_Map.Map;
+   function Get_WMM_Ceofficients return Coefficient_Record_Array;
 end Geo_Mag.Magnetic_Model;


### PR DESCRIPTION
Ada bareboard runtimes doesn't have `Ada.Containers`. Fortunately it can be avoided easily.